### PR TITLE
Properly scaled images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rails', '3.0.9'
 
 gem 'sqlite3'
 gem 'paperclip'
+gem 'paperclip-meta'
 gem 'aws-s3', :require => 'aws/s3'
 gem 'authlogic', :git => 'https://github.com/kreetitech/authlogic.git'
 gem 'formtastic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       activesupport (>= 2.3.2)
       cocaine (>= 0.0.2)
       mime-types
+    paperclip-meta (0.2)
+      paperclip
     polyglot (0.3.1)
     rack (1.2.3)
     rack-mount (0.6.14)
@@ -120,6 +122,7 @@ DEPENDENCIES
   formtastic
   haml
   paperclip
+  paperclip-meta
   rack-openid
   rails (= 3.0.9)
   ruby-debug19

--- a/app/views/users/_image.html.erb
+++ b/app/views/users/_image.html.erb
@@ -1,0 +1,18 @@
+<%
+#default for images that havent been converted over.
+width = height = 300
+style = ""
+
+unless avatar.width.blank? || avatar.height.blank?
+  if avatar.width > avatar.height
+    width = (avatar.width * 300) / avatar.height
+    height = 300
+    style = 'left: -' + ((width-300)/2).to_s  + 'px;'
+  else
+    height = (avatar.height * 300) / avatar.width
+    width = 300
+    style = 'top: -' + ((height-300)/2).to_s  + 'px;'
+  end
+end
+%>
+<%= image_tag avatar.url, {:width => width, :height => height, :style => style} %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 
 	 <div id="person-<% user.id %>" class="person">
 		
-		<img style="display: inline-block" src="<%= user.avatar.url(:medium) %>" width="300" height="300" />
+    <%= render :partial => 'image', :locals => {:avatar => user.avatar} %>
 	
 			<div class="overlay">
 

--- a/db/migrate/20110724131800_add_meta_to_avatars.rb
+++ b/db/migrate/20110724131800_add_meta_to_avatars.rb
@@ -1,0 +1,9 @@
+class AddMetaToAvatars < ActiveRecord::Migration
+  def self.up
+    add_column :users, :avatar_meta,    :text
+  end
+
+  def self.down
+    remove_column :users, :avatar_meta
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110719091808) do
+ActiveRecord::Schema.define(:version => 20110724131800) do
 
   create_table "categories", :force => true do |t|
     t.string   "name"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(:version => 20110719091808) do
     t.datetime "last_login_at"
     t.string   "current_login_ip"
     t.string   "last_login_ip"
+    t.text     "avatar_meta"
   end
 
 end

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -151,6 +151,7 @@ h4 {
   margin: 5px;
 }
 .person img {
+	display: inline-block;
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
Images will automatically scale to proper proportions based on the new avatar meta properties (height/width), and any content larger than 300px will be centered within the .person frame

---

Avatar meta comes from paperclip-meta gem. Access via user.avatar.width / user.avatar.height

To load avatar meta data for current images, run this in console:  User.all.each{|u| u.avatar.reprocess!; u.save!}
